### PR TITLE
Facelift the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+Changelog
+===
+
+### Version 1.5
+
+Release date: _Coming soon_
+
+* Update minimal Java requirement to Java 8
+
+
+### Previous versions
+
+See the commit history.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,55 @@
+/* Only keep the 10 most recent builds. */
+properties([[$class: 'BuildDiscarderProperty',
+                strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
+
+// TODO: Move it to Jenkins Pipeline Library
+
+/* These platforms correspond to labels in ci.jenkins.io, see:
+ *  https://github.com/jenkins-infra/documentation/blob/master/ci.adoc
+ */
+List platforms = ['linux', 'windows']
+Map branches = [:]
+
+for (int i = 0; i < platforms.size(); ++i) {
+    String label = platforms[i]
+    branches[label] = {
+        node(label) {
+            timestamps {
+                stage('Checkout') {
+                    checkout scm
+                }
+
+                stage('Build') {
+                    withEnv([
+                        "JAVA_HOME=${tool 'jdk8'}",
+                        "PATH+MVN=${tool 'mvn'}/bin",
+                        'PATH+JDK=$JAVA_HOME/bin',
+                    ]) {
+                        timeout(30) {
+                            String command = 'mvn --batch-mode clean install -Dmaven.test.failure.ignore=true'
+                            if (isUnix()) {
+                                sh command
+                            }
+                            else {
+                                bat command
+                            }
+                        }
+                    }
+                }
+
+                stage('Archive') {
+                    /* Archive the test results */
+                    junit '**/target/surefire-reports/TEST-*.xml'
+
+                    if (label == 'linux') {
+                      archiveArtifacts artifacts: 'target/**/*.jar'
+                      findbugs pattern: '**/target/findbugsXml.xml'
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* Execute our platforms in parallel */
+parallel(branches)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+Jenkins Task Reactor Library
+---
+
+This library implements a task reactor for Jenkins initialization and reload logic.
+See usages in [jenkins.model.Jenkins](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/Jenkins.java).
+
+## License
+
+[MIT License](http://jenkins-ci.org/mit-license)
+
+## Documentation
+
+* [Changelog](CHANGELOG.md)
+* Javadoc: Coming soon

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,27 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.32</version>
+    <version>1.39</version>
   </parent>
   <artifactId>task-reactor</artifactId>
   <version>1.5-SNAPSHOT</version>
-  <name>Task Reactor</name>
+  <name>Jenkins Task Reactor</name>
+
+  <properties>
+    <java.level>8</java.level>
+  </properties>
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -37,5 +47,30 @@
     <developerConnection>scm:git:git@github.com:jenkinsci/lib-task-reactor.git</developerConnection>
     <url>https://github.com/jenkinsci/lib-task-reactor</url>
   </scm>
+
+  <!-- TODO: remove when library parent POM enables FindBugs by default -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <effort>Max</effort>
+          <threshold>Low</threshold><!-- we want to find serialization related problems -->
+          <!-- TODO: issues need to be fixed first-->
+          <failOnError>false</failOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/main/java/org/jvnet/hudson/reactor/Executable.java
+++ b/src/main/java/org/jvnet/hudson/reactor/Executable.java
@@ -29,9 +29,11 @@ package org.jvnet.hudson.reactor;
  * @author Kohsuke Kawaguchi
  */
 public interface Executable {
+
     /**
      * Executes a task. Any exception thrown will abort the session.
-     * @param reactor
+     * @param reactor Reactor to be executed
+     * @throws Exception Execution error
      */
     void run(Reactor reactor) throws Exception;
 

--- a/src/main/java/org/jvnet/hudson/reactor/Reactor.java
+++ b/src/main/java/org/jvnet/hudson/reactor/Reactor.java
@@ -194,7 +194,7 @@ public class Reactor implements Iterable<Reactor.Node> {
     }
 
     /**
-     * Adds a set of taks to the reactor.
+     * Adds a set of tasks to the reactor.
      *
      * <p>
      * When adding a series of related tasks, it's often necessary to add them as a bulk,

--- a/src/main/java/org/jvnet/hudson/reactor/ReactorListener.java
+++ b/src/main/java/org/jvnet/hudson/reactor/ReactorListener.java
@@ -38,14 +38,18 @@ public interface ReactorListener {
     /**
      * Notifies that the execution of the task is about to start.
      */
-    void onTaskStarted(Task t);
+    default void onTaskStarted(Task t) {
+        // Do nothing by default
+    }
 
     /**
      * Notifies that the execution of the task is about to finish.
      *
      * This happens on the same thread that called {@link #onTaskStarted(Task)}.
      */
-    void onTaskCompleted(Task t);
+    default void onTaskCompleted(Task t) {
+        // Do nothing by default
+    }
 
     /**
      * Notifies that the execution of the task have failed with an exception.
@@ -56,22 +60,19 @@ public interface ReactorListener {
      *      If true, this problem is {@linkplain Task#failureIsFatal() fatal}, and the reactor
      *      is going to terminate. If false, the reactor will continue executing after this failure.
      */
-    void onTaskFailed(Task t, Throwable err, boolean fatal);
+    default void onTaskFailed(Task t, Throwable err, boolean fatal)  {
+        // Do nothing by default
+    }
 
     /**
      * Indicates that the following milestone was attained.
      */
-    void onAttained(Milestone milestone);
+    default void onAttained(Milestone milestone)  {
+        // Do nothing by default
+    }
 
     public static final ReactorListener NOOP = new ReactorListener() {
-        public void onTaskStarted(Task t) {
-        }
-        public void onTaskCompleted(Task t) {
-        }
-        public void onTaskFailed(Task t, Throwable err, boolean fatal) {
-        }
-        public void onAttained(Milestone milestone) {
-        }
+        // Default implementation for all handlers
     };
 
     /**

--- a/src/test/java/org/jvnet/hudson/reactor/SessionTest.java
+++ b/src/test/java/org/jvnet/hudson/reactor/SessionTest.java
@@ -64,18 +64,24 @@ public class SessionTest extends TestCase {
         final PrintWriter w = new PrintWriter(new TeeWriter(sw,new OutputStreamWriter(System.out)),true);
 
         s.execute(Executors.newCachedThreadPool(),new ReactorListener() {
+
+            //TODO: Does it really needs handlers to be synchronized?
+            @Override
             public synchronized void onTaskStarted(Task t) {
                 w.println("Started "+t.getDisplayName());
             }
 
+            @Override
             public synchronized void onTaskCompleted(Task t) {
                 w.println("Ended "+t.getDisplayName());
             }
 
+            @Override
             public synchronized void onTaskFailed(Task t, Throwable err, boolean fatal) {
                 w.println("Failed "+t.getDisplayName()+" with "+err);
             }
 
+            @Override
             public synchronized void onAttained(Milestone milestone) {
                 w.println("Attained "+milestone);
             }


### PR DESCRIPTION
It is a prerequisite for [JENKINS-48728](https://issues.jenkins-ci.org/browse/JENKINS-48728):

- [x] Update Parent POM and Java requirements
- [x] Enable FindBugs
- [x] Add some basic documentation
- [x] Add Jenkinsfile (copy-pasted from Remoting)

I do not like the FindBugs warnings, I will create a follow-up ticket for them: => [JENKINS-48729](https://issues.jenkins-ci.org/browse/JENKINS-48729)

```
[INFO] --- findbugs-maven-plugin:3.0.5:check (default) @ task-reactor ---
[INFO] BugInstance size is 3
[INFO] Error size is 0
[INFO] Total bugs: 3
[INFO] Inconsistent synchronization of org.jvnet.hudson.reactor.Reactor.executor; locked 50% of time [org.jvnet.hudson.reactor.Reactor$Node, org.jvnet.hudson.reactor.Reactor$Node, org.jvnet.hudson.reactor.Reactor, org.jvnet.hudson.reactor.Reactor, org.jvnet.hudson.reactor.Reactor] Unsynchronized access at Reactor.java:[line 139]Unsynchronized access at Reactor.java:[line 109]Synchronized access at Reactor.java:[line 256]Synchronized access at Reactor.java:[line 273]Synchronized access at Reactor.java:[line 273] IS2_INCONSISTENT_SYNC
[INFO] Inconsistent synchronization of org.jvnet.hudson.reactor.Reactor.fatal; locked 75% of time [org.jvnet.hudson.reactor.Reactor$Node, org.jvnet.hudson.reactor.Reactor$Node, org.jvnet.hudson.reactor.Reactor, org.jvnet.hudson.reactor.Reactor] Unsynchronized access at Reactor.java:[line 119]Synchronized access at Reactor.java:[line 126]Synchronized access at Reactor.java:[line 268]Synchronized access at Reactor.java:[line 269] IS2_INCONSISTENT_SYNC
[INFO] Using notify rather than notifyAll in org.jvnet.hudson.reactor.Reactor$Node.run() [org.jvnet.hudson.reactor.Reactor$Node] At Reactor.java:[line 131] NO_NOTIFY_NOT_NOTIFYALL
[INFO] 
```

@reviewbybees 
