### PR TITLE
Confirm that spotbugs 4.8.2 adds no new warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
     <revision>1.9</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
+    <!-- TODO: Remove when parent pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/pom/pull/510 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Draft, not intended to be merged

Prep for

* https://github.com/jenkinsci/pom/pull/510

Part of the checklist in:

* https://github.com/jenkinsci/jenkins/pull/8803

Does not need to be merged because there is no additional suppression required.
